### PR TITLE
BUG: Update multitest.py to remove garbage collection for Holm-Bonferroni

### DIFF
--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -191,7 +191,6 @@ def multipletests(pvals, alpha=0.05, method='hs', is_sorted=False,
         pvals_corrected_raw = pvals * np.arange(ntests, 0, -1)
         pvals_corrected = np.maximum.accumulate(pvals_corrected_raw)
         del pvals_corrected_raw
-        gc.collect()
 
     elif method.lower() in ['sh', 'simes-hochberg']:
         alphash = alphaf / np.arange(ntests, 0, -1)


### PR DESCRIPTION
In using statsmodels for a multiple testing application, I found that the garbage collection call in Holm-Bonferroni makes it much slower (>400X increase in runtime) compared to the other multiple testing methods. Removing the gc.collect() call for parity between Holm-Bonferroni and other multiple testing methods.